### PR TITLE
Increase the depth of the host search.

### DIFF
--- a/index.php
+++ b/index.php
@@ -17,7 +17,7 @@ $path = '..';
 function getHosts( $path ) {
 
 	$array = array();
-	$depth = 1;
+	$depth = 2;
 	$ite   = new RecursiveDirectoryIterator( $path, RecursiveDirectoryIterator::SKIP_DOTS );
 	$files = new RecursiveIteratorIterator( $ite );
 	$files->setMaxDepth( $depth );


### PR DESCRIPTION
Ran into issues where the configuration I used for project management based on [lkwdwrd/vvv-autop-setup](https://github.com/lkwdwrd/vvv-auto-setup) was not being seen by your dashboard. Here I have increased the depth which we take the search to match that of [VVV](https://github.com/Varying-Vagrant-Vagrants/VVV/commit/1523d3851669ef97948f2f18f5932767665bfd81)
