### PR TITLE
Fetch server paths from Nginx configuration files.

### DIFF
--- a/libs/functions.php
+++ b/libs/functions.php
@@ -46,21 +46,12 @@ function vvv_dash_wp_backup( $host, $file_name = '' ) {
 
 	if ( isset( $host ) ) {
 
-		$type = check_host_type( $host );
+		$host_info = vvv_dashboard::get_host_info( $host );
 
-		if ( isset( $type['key'] ) ) {
+		if ( isset( $host_info['path'] ) ) {
 
-			if ( isset( $type['path'] ) ) {
-
-				$path        = VVV_WEB_ROOT . '/' . $type['key'] . $type['path'];
-				$db_settings = get_wp_db_settings( $path );
-
-			} else {
-
-				$path        = VVV_WEB_ROOT . '/' . $type['key'] . '/';
-				$db_settings = get_wp_db_settings( $path );
-
-			}
+			$path        = $host_info['path'];
+			$db_settings = get_wp_db_settings( $path );
 
 		} else {
 

--- a/libs/vvv-dash-hosts.php
+++ b/libs/vvv-dash-hosts.php
@@ -181,8 +181,8 @@ class vvv_dash_hosts {
 
 		$config_array = array();
 
-		$env_file  = $this->get_env_file( $host_info );
-		$env_lines = file( $env_file['env_path'] );
+		list( $env_path, $is_env ) = $this->check_env_file( $host_info );
+		$env_lines = file( $env_path );
 		$lines     = array_splice( $env_lines, 0, 15 );
 		$env_array = array();
 
@@ -268,25 +268,14 @@ class vvv_dash_hosts {
 		return $config_array;
 	}
 
-	public function is_env_site( $host_info ) {
-
-		$env_path = $this->get_env_file($host_info);
-
-		if ( isset($env_path['env_path']) && ! empty($env_path['env_path']) ) {
-			return true;
-		} else {
-			return false;
-		}
-	}
-
-	public function get_env_file( $host_info ) {
+	public function check_env_file( $host_info ) {
 		global $vvv_dash_scan_paths;
 
-		$env_file = array();
+		$env_path = '';
 		$file     = $host_info['path'] . '/.env';
 
 		if ( file_exists( $file ) ) {
-			$env_file['env_path'] = $file;
+			$env_path = $file;
 		} else {
 
 			foreach ( $vvv_dash_scan_paths as $dir ) {
@@ -294,14 +283,14 @@ class vvv_dash_hosts {
 				$file = $host_info['path'] . '/' . $dir . '/.env';
 
 				if ( file_exists( $file ) ) {
-					$env_file['env_path'] = $file;
+					$env_path = $file;
 				}
 
 			} // end foreach
 			unset( $dir );
 		}
 
-		return $env_file;
+		return [ $env_path, $env_path != '' ? true : false ];
 	}
 }
 // End vvv-dash-hosts.php

--- a/libs/vvv-dash-hosts.php
+++ b/libs/vvv-dash-hosts.php
@@ -127,7 +127,7 @@ class vvv_dash_hosts {
 			// Look for a "server { [...] }" block and extract the "server_name" with
 			// our $host and the corresponding "root" path
 			if ( preg_match(
-				"|server\s*{.*server_name\s*($host)\s?.*;.*root\s*(.*?)\s*?;.*}|s",
+				"|server\s*?\{.*?server_name\s*?($host)\s*?.*?;.*?root\s*(.*?)\s*?;.*?\}|s",
 				$conf,
 				$matches
 			) ) {

--- a/libs/vvv-dashboard.php
+++ b/libs/vvv-dashboard.php
@@ -276,25 +276,7 @@ class vvv_dashboard {
 
 		$host_info = array();
 		$hosts     = new vvv_dash_hosts();
-
-		// Are these default hosts
-		$type = $hosts->check_host_type( $host );
-
-		if ( isset( $type['key'] ) ) {
-
-			if ( isset( $type['path'] ) ) {
-				$host_info['host']    = $type['key'];
-				$host_info['path']    = $type['path'];
-				$host_info['content'] = '/wp-content';
-			} else {
-				$host_info['host']    = $type['key'];
-				$host_info['path']    = '/';
-				$host_info['content'] = '/wp-content';
-			}
-
-		} else {
-			$host_info = $hosts->get_paths( $host );
-		}
+		$host_info = $hosts->get_paths( $host );
 
 		$env_file              = $hosts->get_env_file( $host_info );
 		$host_info['is_env']   = $hosts->is_env_site( $host_info );

--- a/libs/vvv-dashboard.php
+++ b/libs/vvv-dashboard.php
@@ -240,7 +240,7 @@ class vvv_dashboard {
 
 			// wp core version --path=<path>
 			if ( $is_env ) {
-				$host_path = '/public/wp';
+				$host_path = $host_info['path'] . '/wp';
 			} else {
 				// Normal WP
 				$host_path = $host_info['path'];

--- a/views/dashboard.php
+++ b/views/dashboard.php
@@ -26,8 +26,8 @@
 				if ( isset( $_GET['host'] ) ) {
 
 					$host      = $_GET['host'];
-					$host_info = $vvv_dash->set_host_info( $host );
-					$host_path = VVV_WEB_ROOT . '/' . $host_info['host'] . $host_info['path'];
+					$host_info = vvv_dashboard::get_host_info( $host );
+					$host_path = $host_info['path'];
 					$fav_file  = VVV_WEB_ROOT . '/default/dashboard/favorites/plugins.txt';
 					// Install fav plugins
 					$checkboxes = $vvv_dash->get_fav_list( $fav_file );
@@ -105,8 +105,8 @@
 
 				$host      = $_GET['host'];
 				$domain    = ( isset( $_GET['domain'] ) ) ? $_GET['domain'] : false;
-				$host_info = $vvv_dash->set_host_info( $host );
-				$host_path = VVV_WEB_ROOT . '/' . $host_info['host'] . $host_info['path'];
+				$host_info = vvv_dashboard::get_host_info( $host );
+				$host_path = $host_info['path'];
 
 				if ( $domain ) {
 					$status = $vvv_dash->create_db_backup( $host );
@@ -232,8 +232,8 @@
 
 					if ( isset( $_POST['create_s_theme'] ) ) {
 						$themes_array = get_csv_names( $themes );
-						$host_info    = $vvv_dash->set_host_info( $_POST['host'] );
-						$host_path    = VVV_WEB_ROOT . '/' . $host_info['host'] . $host_info['path'];
+						$host_info    = vvv_dashboard::get_host_info( $_POST['host'] );
+						$host_path    = $host_info['path'];
 						$slug         = strtolower( str_replace( ' ', '_', $_POST['theme_slug'] ) );
 
 						// @ToDo allow this --force
@@ -259,8 +259,8 @@
 
 						$themes_array = get_csv_names( $themes );
 
-						$host_info = $vvv_dash->set_host_info( $_POST['host'] );
-						$host_path = VVV_WEB_ROOT . '/' . $host_info['host'] . $host_info['path'];
+						$host_info = vvv_dashboard::get_host_info( $_POST['host'] );
+						$host_path = $host_info['path'];
 						$child     = strtolower( str_replace( ' ', '_', $_POST['child'] ) );
 
 						if ( in_array( $child, $themes_array ) ) {
@@ -279,7 +279,7 @@
 						}
 					}
 
-					$host_info = $vvv_dash->set_host_info( $_GET['host'] );
+					$host_info = vvv_dashboard::get_host_info( $_GET['host'] );
 					$themes    = $vvv_dash->get_themes_data( $host_info['host'], $host_info['path'] );
 
 					echo format_table( $themes, $_GET['host'], 'themes' );

--- a/views/hosts-list.php
+++ b/views/hosts-list.php
@@ -38,7 +38,7 @@
 		foreach ( $hosts as $key => $array ) {
 			if ( 'site_count' != $key ) {
 
-				$host_info = $vvv_dash->set_host_info( $array['host'] );
+				$host_info = vvv_dashboard::get_host_info( $array['host'] );
 				$is_env    = ( isset( $host_info['is_env'] ) ) ? $host_info['is_env'] : false;
 
 				$dash_hosts    = new vvv_dash_hosts();
@@ -135,16 +135,10 @@
 							<?php
 						}
 
-						$type = check_host_type( $array['host'] );
+						$host_info = vvv_dashboard::get_host_info( $array['host'] );
 
-						if ( isset( $type['key'] ) ) {
-
-							if ( isset( $type['path'] ) ) {
-								$debug_log_path = VVV_WEB_ROOT . '/' . $type['key'] . '/' . $type['path'] . '/wp-content/debug.log';
-							} else {
-								$debug_log_path = VVV_WEB_ROOT . '/' . $type['key'] . '/wp-content/debug.log';
-							}
-
+						if ( isset( $host_info['path'] ) ) {
+							$debug_log_path = $host_info['path'] . '/wp-content/debug.log';
 						} else {
 							$this_host      = strstr( $array['host'], '.', true );
 							$debug_log_path = VVV_WEB_ROOT . '/' . $this_host . '/htdocs/wp-content/debug.log';


### PR DESCRIPTION
This patch changes the way the `$path` is fetched for each `$host`.

They are both completely different entities, `$path` does not necessarily contain `$host`.

> Example:
> `$host` might be `localsite.dev` whereas `$path` could be `finalserver.com`

The `$path` is fetched from the Nginx configuration files, which means that there's no need to have any special cases hard-coded into the source, like the default sites that come with VVV.
