### PR TITLE
Handle error opening stream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dumps/*
 notes.txt
 favorites/themes.txt
 favorites/plugins.txt
+.idea/

--- a/vvv_dash/commands/favs.php
+++ b/vvv_dash/commands/favs.php
@@ -63,6 +63,11 @@ class favs extends host {
 	}
 
 	public function get_fav_list( $file_path ) {
+
+		if ( ! file_exists( $file_path ) ) {
+			return '';
+		};
+
 		$content    = file_get_contents( $file_path );
 		$content    = explode( "\n", $content );
 		$content    = array_filter( $content );


### PR DESCRIPTION
Resolve #40. Handle "failed to open stream" error when trying to open non-existent file.